### PR TITLE
added filters to the issue's endpoint

### DIFF
--- a/django/issues/models.py
+++ b/django/issues/models.py
@@ -1,3 +1,4 @@
+# pylint: disable=import-error
 from autoslug import AutoSlugField
 
 from django.db import models

--- a/django/issues/viewsets.py
+++ b/django/issues/viewsets.py
@@ -1,14 +1,24 @@
-
-
 from rest_framework import permissions, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
+from django_filters import rest_framework as filters
 
 from comments.serializers import CommentarySerializer
 from issues.serializers import IssueSerializer
 from issues.models import Issue, Vote
 
 
+class IssueFilter(filters.FilterSet):
+    title = filters.CharFilter(field_name="title", lookup_expr="icontains", label="Titulo da Issue")
+    description = filters.CharFilter(field_name="description", lookup_expr="icontains", label="Descrição")
+    start_date = filters.DateTimeFilter(field_name="created_at", lookup_expr="gt", label="Data de inicio")
+    end_date = filters.DateTimeFilter(field_name="created_at", lookup_expr="lt", label="Data final")
+
+    class Meta:
+        model = Issue
+        fields = ['title', 'description', 'start_date', 'end_date']
+
+ 
 class IssueViewSet(viewsets.ModelViewSet):  # pylint:disable=too-many-ancestors
     """
     API endpoint to Issues.
@@ -19,9 +29,9 @@ class IssueViewSet(viewsets.ModelViewSet):  # pylint:disable=too-many-ancestors
         token = self.request.GET.get('token', False)
         if self.request.data.get('token', False):
             token = self.request.data.get('token')
-        context.update({'token': token})
+        context.update({'token': token}) 
         return context
-
+        
     @action(detail=True, methods=['post'], name='Issue Rate',
             url_path='rate', url_name='rate')
     def rate(self, request, slug=None):  # pylint:disable=unused-argument
@@ -60,4 +70,6 @@ class IssueViewSet(viewsets.ModelViewSet):  # pylint:disable=too-many-ancestors
     serializer_class = IssueSerializer
     permission_classes = [permissions.AllowAny]
     queryset = Issue.objects.all()
+    ilter_backends = (filters.DjangoFilterBackend,)
+    filterset_class = IssueFilter
     lookup_field = 'slug'

--- a/django/issues/viewsets.py
+++ b/django/issues/viewsets.py
@@ -4,10 +4,9 @@ from rest_framework.response import Response
 from django_filters import rest_framework as filters
 
 from comments.serializers import CommentarySerializer
-from comments.models import Commentary
 from issues.serializers import IssueSerializer
 from issues.models import Issue, Vote
-from users.models import User
+
 
 class IssueFilter(filters.FilterSet):
     """

--- a/django/issues/viewsets.py
+++ b/django/issues/viewsets.py
@@ -4,9 +4,10 @@ from rest_framework.response import Response
 from django_filters import rest_framework as filters
 
 from comments.serializers import CommentarySerializer
+from comments.models import Commentary
 from issues.serializers import IssueSerializer
 from issues.models import Issue, Vote
-
+from users.models import User
 
 class IssueFilter(filters.FilterSet):
     """
@@ -76,6 +77,6 @@ class IssueViewSet(viewsets.ModelViewSet):  # pylint:disable=too-many-ancestors
     serializer_class = IssueSerializer
     permission_classes = [permissions.AllowAny]
     queryset = Issue.objects.all()
-    ilter_backends = (filters.DjangoFilterBackend,)
+    filter_backends = (filters.DjangoFilterBackend,)
     filterset_class = IssueFilter
     lookup_field = 'slug'

--- a/django/issues/viewsets.py
+++ b/django/issues/viewsets.py
@@ -9,16 +9,22 @@ from issues.models import Issue, Vote
 
 
 class IssueFilter(filters.FilterSet):
+    """
+    Filters to the Issue's endpoint
+    """
     title = filters.CharFilter(field_name="title", lookup_expr="icontains", label="Titulo da Issue")
     description = filters.CharFilter(field_name="description", lookup_expr="icontains", label="Descrição")
     start_date = filters.DateTimeFilter(field_name="created_at", lookup_expr="gt", label="Data de inicio")
     end_date = filters.DateTimeFilter(field_name="created_at", lookup_expr="lt", label="Data final")
 
     class Meta:
+        """
+        Filter options
+        """
         model = Issue
         fields = ['title', 'description', 'start_date', 'end_date']
 
- 
+
 class IssueViewSet(viewsets.ModelViewSet):  # pylint:disable=too-many-ancestors
     """
     API endpoint to Issues.
@@ -29,9 +35,9 @@ class IssueViewSet(viewsets.ModelViewSet):  # pylint:disable=too-many-ancestors
         token = self.request.GET.get('token', False)
         if self.request.data.get('token', False):
             token = self.request.data.get('token')
-        context.update({'token': token}) 
+        context.update({'token': token})
         return context
-        
+
     @action(detail=True, methods=['post'], name='Issue Rate',
             url_path='rate', url_name='rate')
     def rate(self, request, slug=None):  # pylint:disable=unused-argument

--- a/django/project/settings.py
+++ b/django/project/settings.py
@@ -25,6 +25,7 @@ EXTERNAL_APPS = [
     'autoslug',
     'corsheaders',
     'rest_framework',
+    'django_filters',
     'rest_framework.authtoken',
 ]
 
@@ -159,6 +160,10 @@ REST_FRAMEWORK = {
     'DEFAULT_RENDERER_CLASSES': DEFAULT_RENDERER_CLASSES,
     'DATETIME_FORMAT': '%d/%m/%Y %H:%M:%S',
     'DATE_FORMAT': '%d/%m/%Y',
+    'DEFAULT_FILTER_BACKENDS': (
+        'django_filters.rest_framework.DjangoFilterBackend',
+
+    ),
 }
 
 CORS_ALLOW_ALL_ORIGINS = True

--- a/django/project/settings.py
+++ b/django/project/settings.py
@@ -162,7 +162,6 @@ REST_FRAMEWORK = {
     'DATE_FORMAT': '%d/%m/%Y',
     'DEFAULT_FILTER_BACKENDS': (
         'django_filters.rest_framework.DjangoFilterBackend',
-
     ),
 }
 

--- a/django/users/urls.py
+++ b/django/users/urls.py
@@ -1,7 +1,6 @@
 # pylint: disable=invalid-name
-from django.urls import re_path
 from rest_framework.authtoken import views
-
+from django.urls import re_path
 
 app_name = 'users'
 urlpatterns = [

--- a/docker/requirements/main.txt
+++ b/docker/requirements/main.txt
@@ -3,6 +3,7 @@ django-autoslug==1.9.8
 django-cleanup==5.1.0
 django-cors-headers==3.7.0
 djangorestframework==3.12.2
+django-filter==21.1
 uritemplate==3.0.1
 pillow==8.3.2
 psycopg2==2.9.2


### PR DESCRIPTION
#### Filters at issue's endpoint

The filters were added to be possible do requests filtering the content in the front-end,  now it's possible to filter by:
- Issue's title
- Issue's description
- By date
  - start_date ( created_at ) will search issues with dates greater than the specified
  - end_date ( created_at ) will search issues with dates less than the specified
  - both will search between  start_date and end_date

